### PR TITLE
修复chatgpt相关功能不能用的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ Mako==1.2.3
 MarkupSafe==2.1.1
 matplotlib-inline==0.1.6
 msgpack==1.0.4
-openai==0.27.2
+openai==0.27.8
 outcome==1.2.0
 parse==1.19.0
 parsel==1.6.0


### PR DESCRIPTION
更新openai sdk的版本至最新的0.27.8