### PR TITLE
fix: 无 season 信息时转移出错

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -554,15 +554,16 @@ class FileTransfer:
                          f"类型：{download_info.TYPE}")
                 media_type = MediaType.MOVIE if download_info.TYPE in MovieTypes else MediaType.TV
                 tmdb_info = self.media.get_tmdb_info(mtype=media_type, tmdbid=download_info.TMDBID)
-                season_str = download_info.SE.split(" ")[0]
-                season = int(season_str[1:len(season_str)])
-                if len(download_info.SE.split(" ")) > 1:
-                    episode_str = download_info.SE.split(" ")[1]
-                    if episode_str.find("-") == -1:
-                        episode = (
-                            EpisodeFormat(eformat="", details=episode_str.replace("E", "")),
-                            False
-                        )
+                if download_info.SE:
+                    season_str = download_info.SE.split(" ")[0]
+                    season = int(season_str[1:len(season_str)])
+                    if len(download_info.SE.split(" ")) > 1:
+                        episode_str = download_info.SE.split(" ")[1]
+                        if episode_str.find("-") == -1:
+                            episode = (
+                                EpisodeFormat(eformat="", details=episode_str.replace("E", "")),
+                                False
+                            )
 
         # 成功标识
         success_flag = True


### PR DESCRIPTION
错误信息：
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/nas-tools/app/sync.py", line 299, in transfer_mon_files
    ret, ret_msg = self.filetransfer.transfer_media(in_from=SyncType.MON,
  File "/nas-tools/app/filetransfer.py", line 558, in transfer_media
    season = int(season_str[1:len(season_str)])
ValueError: invalid literal for int() with base 10: ''
```