### PR TITLE
fix: 修复单站连通性测试默认显示词为通过

### DIFF
--- a/web/templates/site/site.html
+++ b/web/templates/site/site.html
@@ -681,8 +681,8 @@
   function show_site_test(siteid, sitename){
     $("#sitetest_siteid").val(siteid);
     $("#sitetest_modal_title").text("站点测试 - " + sitename);
-    $(`#single_sitetest_item`).html('<span class="badge bg-green me-1 mb-1">是</span>');
-    $(`#single_sitetest_item_time`).html(`<span class="text-green">0 毫秒</span>`);
+    $(`#single_sitetest_item`).html('<span class="badge bg-yellow me-1 mb-1">待测试</span>'); 
+    $(`#single_sitetest_item_time`).html(`<span class="text-muted">等待测试中...</span>`); 
     $(`#single_sitetest_item_msg`).html('');
 
     $("#single_sitetest_btn").text("测试").attr("disabled", false);


### PR DESCRIPTION
[fix: 修复单站连通性测试默认显示词为通过](https://github.com/jackloves111/linyuan0213-nastools/commit/302891139b7b54e0aac05556d4e40974c9f6d67b)

![image](https://github.com/linyuan0213/nas-tools/assets/89971817/f5c9cd53-1c71-4c4f-9526-697fa0221312)
