### PR TITLE
fix: 修复标题副标题没有集数无法订阅的问题

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -907,7 +907,14 @@ class Downloader:
                                 continue
                             item_episodes = item.get_episode_list()
                             if not item_episodes:
-                                continue
+                                # 有时，就算标题副标题没有集数，种子内文件名本身仍然可能是含有集数的。我们打开种子文件来一探究竟。
+                                torrent_episodes, torrent_path = self.get_torrent_episodes(
+                                    url=item.enclosure,
+                                    page_url=item.page_url)
+                                if not torrent_episodes:
+                                    continue
+                                else:
+                                    item_episodes = torrent_episodes
                             # 为需要集的子集则下载
                             if set(item_episodes).issubset(set(need_episodes)):
                                 _, download_id = __download(item)


### PR DESCRIPTION
fix: 修复纵使种子内的文件名含有所有需要的剧集时，如果标题或副标题没有写明集数范围时，该种子也不会被下载的问题