### PR TITLE
修复冰淇淋(icc2022)副标题不显示的BUG

### DIFF
--- a/config/site_manage/sites/冰淇淋(icc2022).json
+++ b/config/site_manage/sites/冰淇淋(icc2022).json
@@ -190,12 +190,12 @@
                 ]
             },
             "description": {
-                "selector": "table.torrentname > tr > td:nth-child(2)",
+                "selector": "table.torrentname > tr > td:nth-child(1)",
                 "remove": "a,b,img,span",
                 "contents": -1
             },
             "labels": {
-                "selector": "table.torrentname > tr > td:nth-child(2) > span"
+                "selector": "table.torrentname > tr > td:nth-child(1) > span"
             },
             "minimumratio": {
                 "text": 1


### PR DESCRIPTION
修复冰淇淋(icc2022)副标题不显示的BUG