### PR TITLE
更新OpenAI API Url，兼容gemini

### DIFF
--- a/app/helper/openai_helper.py
+++ b/app/helper/openai_helper.py
@@ -20,7 +20,7 @@ class OpenAiHelper(metaclass=SingletonMeta):
         api_url = config.get("api_url")
         api_base = None
         if api_url:
-            api_base = f"{api_url}/v1"
+            api_base = f"{api_url}/"
 
         proxy_conf = Config().get_proxies()
         proxy = proxy_conf.get("https")

--- a/app/helper/openai_helper.py
+++ b/app/helper/openai_helper.py
@@ -20,7 +20,7 @@ class OpenAiHelper(metaclass=SingletonMeta):
         api_url = config.get("api_url")
         api_base = None
         if api_url:
-            api_base = f"{api_url}/"
+            api_base = f"{api_url}"
 
         proxy_conf = Config().get_proxies()
         proxy = proxy_conf.get("https")

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -281,10 +281,10 @@
               <div class="col-lg">
                 <div class="mb-3">
                   <label class="form-label">OpenAI API Url <span class="form-help"
-                                                                        title="自定义openai请求地址（请注意格式，请求地址需带有请求头且最后没有/号），不填默认使用https://api.openai.com"
+                                                                        title="自定义openai请求地址（请注意格式，请求地址需带有请求头，以及例如/v1的版本号，并且最后没有/号），不填默认使用https://api.openai.com/v1。兼容非标准api的gemini，可填写https://generativelanguage.googleapis.com/v1beta/openai"
                                                                         data-bs-toggle="tooltip">?</span></label>
                   <input type="text" value="{% if Config.openai %}{{ Config.openai.api_url or '' }}{% endif %}" class="form-control"
-                         id="openai.api_url" placeholder="https://api.openai.com" autocomplete="off">
+                         id="openai.api_url" placeholder="https://api.openai.com/v1" autocomplete="off">
                 </div>
               </div>
               <div class="col-lg">


### PR DESCRIPTION
gemini现在可以使用 OpenAI 库访问 Gemini 模型，使用的是"https://generativelanguage.googleapis.com/v1beta/openai/"，不是标准openai api接口。
具体参考：https://ai.google.dev/gemini-api/docs/openai?hl=zh-cn